### PR TITLE
Add partition key to container init

### DIFF
--- a/models/bottlesDao.js
+++ b/models/bottlesDao.js
@@ -35,9 +35,23 @@ class BottlesDao {
     debug("Setting up the container...");
     const coResponse = await this.database.containers.createIfNotExists({
       id: this.collectionId,
+      partitionKey: "/id",
     });
     this.container = coResponse.container;
     debug("Setting up the container...done!");
+    /*
+      IMPORTANT please finish container setup by adding spatial indexing
+      https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/query/geospatial-index
+      
+      "spatialIndexes": [
+          {
+              "path": "/*",
+              "types": [
+                  "Point"
+              ]
+          }
+      ],
+    */
   }
 
   async init() {


### PR DESCRIPTION
Also added a note to add spatial indexing manually after initializing a container. I couldn't find a way to programmatically set the spatial indexing through the JavaScript SDK, but realistically the `/deleteAll` will be exclusively used by devs anyway.